### PR TITLE
Allow host to be specified

### DIFF
--- a/winerp/client.py
+++ b/winerp/client.py
@@ -29,6 +29,8 @@ class Client:
     local_name: :class:`str`
         The name which will be used to refer to this client.
         This should be unique to all the clients.
+    host: Optional[:class:`str`]
+        The port on which the server is running. Defaults to localhost.
     port: Optional[:class:`int`]
         The port on which the server is running. Defaults to 13254.
     reconnect: Optional[:class:`bool`]
@@ -38,10 +40,11 @@ class Client:
     def __init__(
         self,
         local_name: str,
+        host: str = "localhost",
         port: int = 13254,
         reconnect: bool = True
     ):
-        self.uri: str = f"ws://localhost:{port}"        
+        self.uri: str = f"ws://{host}:{port}"        
         self.local_name: str = local_name
         self.reconnect: bool = reconnect
         self.reconnect_threshold: int = 60

--- a/winerp/server.py
+++ b/winerp/server.py
@@ -18,11 +18,14 @@ class Server:
     
     Parameters
     -----------
+    host: Optional[:class:`str`]
+        The host on which the server is running. Defaults to 127.0.0.1.
     port: Optional[:class:`int`]
         The port on which the server is running. Defaults to 13254.
     """
     def __init__(
         self,
+        host: str = "127.0.0.1",
         port: int = 13254
     ):
         self.websocket = WebsocketServer(host='127.0.0.1', port=port)


### PR DESCRIPTION
in case of development with docker, starting the server in a different container and the client in different container makes it impossible for us to make them communicate without allowing us to pass the host. Because if the server is in a different container and the port is not published to the host, its no longer `localhost` 